### PR TITLE
Add password-protected blog admin (create/edit posts), file helpers, and embed support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,22 @@ Use a `python-run` fenced code block to include Python that readers can execute 
 
 ````md
 ```python-run
-print("hello from python")
+import numpy as np
+print(np.arange(5))
 ```
 ````
+
+### Choosing libraries for each post
+
+In the admin create/edit form, select the Python libraries needed for that post (currently: `numpy`, `matplotlib`, `pandas`, `scipy`).
+
+Those selections are saved in post frontmatter as `pythonPackages`, for example:
+
+```md
+pythonPackages: "numpy, matplotlib"
+```
+
+At runtime, selected libraries are preloaded before snippet execution.
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,31 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Blog admin
+
+The blog supports password-protected admin editing routes.
+
+1. Set an environment variable:
+
+```bash
+BLOG_ADMIN_PASSWORD=your-strong-password
+```
+
+2. Visit `/admin/login` and sign in.
+3. Manage posts at `/admin/blog`.
+
+### Embedding interactive demos in posts
+
+Inside post markdown content, use a fenced code block with the `embed` language and provide a single URL:
+
+````md
+```embed
+https://stackblitz.com/edit/your-demo
+```
+````
+
+Allowed hosts are restricted to `codepen.io`, `codesandbox.io`, and `stackblitz.com`.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/README.md
+++ b/README.md
@@ -20,20 +20,60 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
-## Blog admin
+## Blog admin password setup (local and deployed)
 
-The blog supports password-protected admin editing routes.
+The blog supports password-protected admin editing routes and uses two environment variables:
 
-1. Set an environment variable:
+- `BLOG_ADMIN_PASSWORD` (required): the password you type on `/admin/login`.
+- `BLOG_ADMIN_SESSION_SECRET` (recommended): secret used to sign session cookies.
+  - If this is not set, the app falls back to `BLOG_ADMIN_PASSWORD`.
 
-```bash
-BLOG_ADMIN_PASSWORD=your-strong-password
+### Local development
+
+Set env vars before starting your dev server.
+
+PowerShell:
+
+```powershell
+$env:BLOG_ADMIN_PASSWORD="replace-with-strong-password"
+$env:BLOG_ADMIN_SESSION_SECRET="replace-with-long-random-secret"
+npm run dev
 ```
 
-2. Visit `/admin/login` and sign in.
-3. Manage posts at `/admin/blog`.
+Command Prompt:
 
-### Embedding interactive demos in posts
+```cmd
+set BLOG_ADMIN_PASSWORD=replace-with-strong-password
+set BLOG_ADMIN_SESSION_SECRET=replace-with-long-random-secret
+npm run dev
+```
+
+Then:
+
+1. Open `/admin/login`
+2. Enter `BLOG_ADMIN_PASSWORD`
+3. If correct, a signed cookie session is set and you can manage posts at `/admin/blog`
+
+### Deployed environments (Vercel / Netlify / server-hosted Next.js)
+
+Set the same environment variables in your hosting provider settings:
+
+- `BLOG_ADMIN_PASSWORD`
+- `BLOG_ADMIN_SESSION_SECRET`
+
+After saving, **redeploy** so the server sees updated env vars.
+
+### Important: GitHub Pages behavior
+
+GitHub Pages is static hosting and does not run the server-side auth logic used by this app. That means:
+
+- `/admin/login` server actions will not work there.
+- `next/headers` cookie/session auth checks will not work there.
+- This password-protected admin flow requires a platform that supports Next.js server features.
+
+If you need GitHub Pages specifically, use an external CMS or move admin/auth to a separate backend.
+
+## Embedding interactive demos in posts
 
 Inside post markdown content, use a fenced code block with the `embed` language and provide a single URL:
 
@@ -44,6 +84,21 @@ https://stackblitz.com/edit/your-demo
 ````
 
 Allowed hosts are restricted to `codepen.io`, `codesandbox.io`, and `stackblitz.com`.
+
+## Runnable Python snippets in blog posts
+
+Use a `python-run` fenced code block to include Python that readers can execute in-browser (Pyodide).
+
+````md
+```python-run
+print("hello from python")
+```
+````
+
+Notes:
+
+- Readers can run code and see output, but the blog page does not expose an editor for changing snippet code.
+- Execution happens in the browser runtime, not on your server.
 
 ## Learn More
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Then:
 1. Open `/admin/login`
 2. Enter `BLOG_ADMIN_PASSWORD`
 3. If correct, a signed cookie session is set and you can manage posts at `/admin/blog`
+4. In create/edit, the Date & time field is optional. If left empty, the save time is used automatically (to the minute).
+5. Posts can be deleted from the admin list or from the edit page “Danger zone”.
 
 ### Deployed environments (Vercel / Netlify / server-hosted Next.js)
 
@@ -115,7 +117,7 @@ Those selections are saved in post frontmatter as `pythonPackages`, for example:
 pythonPackages: "numpy, matplotlib"
 ```
 
-At runtime, selected libraries are preloaded before snippet execution.
+At runtime, selected libraries are preloaded before snippet execution. If a package is not in the default Pyodide bundle (for example `seaborn`), the runner attempts installation via `micropip` in-browser.
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ set BLOG_ADMIN_SESSION_SECRET=replace-with-long-random-secret
 npm run dev
 ```
 
+
+Linux/macOS (bash/zsh):
+
+```bash
+export BLOG_ADMIN_PASSWORD="replace-with-strong-password"
+export BLOG_ADMIN_SESSION_SECRET="replace-with-long-random-secret"
+npm run dev
+```
+
 Then:
 
 1. Open `/admin/login`
@@ -98,7 +107,7 @@ print(np.arange(5))
 
 ### Choosing libraries for each post
 
-In the admin create/edit form, select the Python libraries needed for that post (currently: `numpy`, `matplotlib`, `pandas`, `scipy`).
+In the admin create/edit form, select common Python libraries (`numpy`, `matplotlib`, `pandas`, `scipy`) and optionally add extra libraries in the “Additional Python libraries” field.
 
 Those selections are saved in post frontmatter as `pythonPackages`, for example:
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Then:
 1. Open `/admin/login`
 2. Enter `BLOG_ADMIN_PASSWORD`
 3. If correct, a signed cookie session is set and you can manage posts at `/admin/blog`
-4. In create/edit, the Date & time field is optional. If left empty, the save time is used automatically (to the minute).
+4. Date & time defaults to the editor's current local timezone time. If the date is missing at submit, server fallback uses the submitted timezone, then defaults to America/New_York.
 5. Posts can be deleted from the admin list or from the edit page “Danger zone”.
 
 ### Deployed environments (Vercel / Netlify / server-hosted Next.js)

--- a/src/app/admin/blog/[slug]/page.tsx
+++ b/src/app/admin/blog/[slug]/page.tsx
@@ -26,11 +26,16 @@ export default async function EditPostPage({ params }: { params: Promise<{ slug:
       date: String(formData.get('date') ?? ''),
       excerpt: String(formData.get('excerpt') ?? ''),
       tags: String(formData.get('tags') ?? ''),
-      pythonPackages: formData
-        .getAll('pythonPackages')
-        .map((pkg) => String(pkg).trim())
-        .filter(Boolean)
-        .join(', '),
+      pythonPackages: Array.from(new Set([
+        ...formData
+          .getAll('pythonPackages')
+          .map((pkg) => String(pkg).trim())
+          .filter(Boolean),
+        ...String(formData.get('pythonPackagesExtra') ?? '')
+          .split(',')
+          .map((pkg) => pkg.trim())
+          .filter(Boolean),
+      ])).join(', '),
       content: String(formData.get('content') ?? ''),
     };
 
@@ -41,6 +46,8 @@ export default async function EditPostPage({ params }: { params: Promise<{ slug:
     updatePostFile(slug, payload);
     redirect(`/admin/blog/${slug}?saved=1`);
   }
+
+  const customPythonPackages = (post.pythonPackages ?? []).filter((pkg) => !AVAILABLE_PYTHON_PACKAGES.includes(pkg));
 
   return (
     <main className="bg-[#000000] min-h-screen text-white px-4 py-8 md:px-10 lg:px-24">
@@ -96,6 +103,17 @@ export default async function EditPostPage({ params }: { params: Promise<{ slug:
               ))}
             </div>
           </fieldset>
+
+
+          <label className="space-y-1 block">
+            <span className="text-sm text-[#a0a0a5]">Additional Python libraries (optional, comma-separated)</span>
+            <input
+              name="pythonPackagesExtra"
+              defaultValue={customPythonPackages.join(', ')}
+              placeholder="sympy, seaborn"
+              className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2"
+            />
+          </label>
 
           <label className="space-y-1 block">
             <span className="text-sm text-[#a0a0a5]">Content (Markdown)</span>

--- a/src/app/admin/blog/[slug]/page.tsx
+++ b/src/app/admin/blog/[slug]/page.tsx
@@ -1,0 +1,93 @@
+import { getPostData } from '@/lib/blog';
+import { requireAdminAuth } from '@/lib/admin-auth';
+import { updatePostFile, type PostFormInput } from '@/lib/blog-admin';
+import Link from 'next/link';
+import { notFound, redirect } from 'next/navigation';
+
+export default async function EditPostPage({ params }: { params: Promise<{ slug: string }> }) {
+  await requireAdminAuth();
+
+  const { slug } = await params;
+  const post = getPostData(slug);
+
+  if (!post) {
+    notFound();
+  }
+
+  async function updatePost(formData: FormData) {
+    'use server';
+
+    await requireAdminAuth();
+
+    const payload: PostFormInput = {
+      title: String(formData.get('title') ?? ''),
+      date: String(formData.get('date') ?? ''),
+      excerpt: String(formData.get('excerpt') ?? ''),
+      tags: String(formData.get('tags') ?? ''),
+      content: String(formData.get('content') ?? ''),
+    };
+
+    if (!payload.title || !payload.date || !payload.content) {
+      redirect(`/admin/blog/${slug}?error=missing`);
+    }
+
+    updatePostFile(slug, payload);
+    redirect(`/admin/blog/${slug}?saved=1`);
+  }
+
+  return (
+    <main className="bg-[#000000] min-h-screen text-white px-4 py-8 md:px-10 lg:px-24">
+      <div className="max-w-4xl mx-auto space-y-6">
+        <div className="flex items-center justify-between gap-4">
+          <h1 className="text-3xl font-bold">Edit post</h1>
+          <Link href="/admin/blog" className="text-sm text-[#95bdc9] hover:text-white">
+            ← Back to admin
+          </Link>
+        </div>
+
+        <form action={updatePost} className="rounded-2xl border border-[#2C2C2E] bg-[#1C1C1E] p-6 space-y-4">
+          <label className="space-y-1 block">
+            <span className="text-sm text-[#a0a0a5]">Title</span>
+            <input name="title" defaultValue={post.title} required className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2" />
+          </label>
+
+          <label className="space-y-1 block">
+            <span className="text-sm text-[#a0a0a5]">Date</span>
+            <input
+              name="date"
+              type="date"
+              defaultValue={post.date.slice(0, 10)}
+              required
+              className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2"
+            />
+          </label>
+
+          <label className="space-y-1 block">
+            <span className="text-sm text-[#a0a0a5]">Excerpt</span>
+            <input name="excerpt" defaultValue={post.excerpt} className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2" />
+          </label>
+
+          <label className="space-y-1 block">
+            <span className="text-sm text-[#a0a0a5]">Tags (comma-separated)</span>
+            <input name="tags" defaultValue={post.tags?.join(', ')} className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2" />
+          </label>
+
+          <label className="space-y-1 block">
+            <span className="text-sm text-[#a0a0a5]">Content (Markdown)</span>
+            <textarea
+              name="content"
+              rows={14}
+              defaultValue={post.content}
+              required
+              className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2 font-mono text-sm"
+            />
+          </label>
+
+          <button type="submit" className="rounded-md bg-[#95bdc9] text-black font-semibold px-4 py-2 hover:opacity-90">
+            Save changes
+          </button>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/src/app/admin/blog/[slug]/page.tsx
+++ b/src/app/admin/blog/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { requireAdminAuth } from '@/lib/admin-auth';
 import { deletePostFile, updatePostFile, type PostFormInput } from '@/lib/blog-admin';
 import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
+import { DateTimeField } from '@/components/date-time-field';
 
 const AVAILABLE_PYTHON_PACKAGES = ['numpy', 'matplotlib', 'pandas', 'scipy'];
 
@@ -24,6 +25,7 @@ export default async function EditPostPage({ params }: { params: Promise<{ slug:
     const payload: PostFormInput = {
       title: String(formData.get('title') ?? ''),
       date: String(formData.get('date') ?? ''),
+      timezone: String(formData.get('timezone') ?? ''),
       excerpt: String(formData.get('excerpt') ?? ''),
       tags: String(formData.get('tags') ?? ''),
       pythonPackages: Array.from(
@@ -76,14 +78,8 @@ export default async function EditPostPage({ params }: { params: Promise<{ slug:
           </label>
 
           <label className="space-y-1 block">
-            <span className="text-sm text-[#a0a0a5]">Date & time (optional)</span>
-            <input
-              name="date"
-              type="datetime-local"
-              defaultValue={post.date.slice(0, 16)}
-              className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2"
-            />
-            <p className="text-xs text-[#7f7f82]">Leave empty to auto-use the current date/time at save.</p>
+            <span className="text-sm text-[#a0a0a5]">Date & time</span>
+            <DateTimeField initialDate={post.date} />
           </label>
 
           <label className="space-y-1 block">

--- a/src/app/admin/blog/[slug]/page.tsx
+++ b/src/app/admin/blog/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { getPostData } from '@/lib/blog';
 import { requireAdminAuth } from '@/lib/admin-auth';
-import { updatePostFile, type PostFormInput } from '@/lib/blog-admin';
+import { deletePostFile, updatePostFile, type PostFormInput } from '@/lib/blog-admin';
 import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
 
@@ -26,25 +26,35 @@ export default async function EditPostPage({ params }: { params: Promise<{ slug:
       date: String(formData.get('date') ?? ''),
       excerpt: String(formData.get('excerpt') ?? ''),
       tags: String(formData.get('tags') ?? ''),
-      pythonPackages: Array.from(new Set([
-        ...formData
-          .getAll('pythonPackages')
-          .map((pkg) => String(pkg).trim())
-          .filter(Boolean),
-        ...String(formData.get('pythonPackagesExtra') ?? '')
-          .split(',')
-          .map((pkg) => pkg.trim())
-          .filter(Boolean),
-      ])).join(', '),
+      pythonPackages: Array.from(
+        new Set([
+          ...formData
+            .getAll('pythonPackages')
+            .map((pkg) => String(pkg).trim())
+            .filter(Boolean),
+          ...String(formData.get('pythonPackagesExtra') ?? '')
+            .split(',')
+            .map((pkg) => pkg.trim())
+            .filter(Boolean),
+        ]),
+      ).join(', '),
       content: String(formData.get('content') ?? ''),
     };
 
-    if (!payload.title || !payload.date || !payload.content) {
+    if (!payload.title || !payload.content) {
       redirect(`/admin/blog/${slug}?error=missing`);
     }
 
     updatePostFile(slug, payload);
     redirect(`/admin/blog/${slug}?saved=1`);
+  }
+
+  async function deletePost() {
+    'use server';
+
+    await requireAdminAuth();
+    deletePostFile(slug);
+    redirect('/admin/blog?deleted=1');
   }
 
   const customPythonPackages = (post.pythonPackages ?? []).filter((pkg) => !AVAILABLE_PYTHON_PACKAGES.includes(pkg));
@@ -66,14 +76,14 @@ export default async function EditPostPage({ params }: { params: Promise<{ slug:
           </label>
 
           <label className="space-y-1 block">
-            <span className="text-sm text-[#a0a0a5]">Date</span>
+            <span className="text-sm text-[#a0a0a5]">Date & time (optional)</span>
             <input
               name="date"
-              type="date"
-              defaultValue={post.date.slice(0, 10)}
-              required
+              type="datetime-local"
+              defaultValue={post.date.slice(0, 16)}
               className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2"
             />
+            <p className="text-xs text-[#7f7f82]">Leave empty to auto-use the current date/time at save.</p>
           </label>
 
           <label className="space-y-1 block">
@@ -104,13 +114,12 @@ export default async function EditPostPage({ params }: { params: Promise<{ slug:
             </div>
           </fieldset>
 
-
           <label className="space-y-1 block">
             <span className="text-sm text-[#a0a0a5]">Additional Python libraries (optional, comma-separated)</span>
             <input
               name="pythonPackagesExtra"
               defaultValue={customPythonPackages.join(', ')}
-              placeholder="sympy, seaborn"
+              placeholder="seaborn, sympy"
               className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2"
             />
           </label>
@@ -126,8 +135,17 @@ export default async function EditPostPage({ params }: { params: Promise<{ slug:
             />
           </label>
 
-          <button type="submit" className="rounded-md bg-[#95bdc9] text-black font-semibold px-4 py-2 hover:opacity-90">
-            Save changes
+          <div className="flex flex-wrap items-center gap-3">
+            <button type="submit" className="rounded-md bg-[#95bdc9] text-black font-semibold px-4 py-2 hover:opacity-90">
+              Save changes
+            </button>
+          </div>
+        </form>
+
+        <form action={deletePost} className="rounded-2xl border border-red-900/60 bg-red-950/20 p-4">
+          <p className="text-sm text-red-300 mb-3">Danger zone: permanently delete this post.</p>
+          <button type="submit" className="rounded-md border border-red-800/80 px-4 py-2 text-red-300 hover:border-red-500">
+            Delete post
           </button>
         </form>
       </div>

--- a/src/app/admin/blog/[slug]/page.tsx
+++ b/src/app/admin/blog/[slug]/page.tsx
@@ -4,6 +4,8 @@ import { updatePostFile, type PostFormInput } from '@/lib/blog-admin';
 import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
 
+const AVAILABLE_PYTHON_PACKAGES = ['numpy', 'matplotlib', 'pandas', 'scipy'];
+
 export default async function EditPostPage({ params }: { params: Promise<{ slug: string }> }) {
   await requireAdminAuth();
 
@@ -24,6 +26,11 @@ export default async function EditPostPage({ params }: { params: Promise<{ slug:
       date: String(formData.get('date') ?? ''),
       excerpt: String(formData.get('excerpt') ?? ''),
       tags: String(formData.get('tags') ?? ''),
+      pythonPackages: formData
+        .getAll('pythonPackages')
+        .map((pkg) => String(pkg).trim())
+        .filter(Boolean)
+        .join(', '),
       content: String(formData.get('content') ?? ''),
     };
 
@@ -71,6 +78,24 @@ export default async function EditPostPage({ params }: { params: Promise<{ slug:
             <span className="text-sm text-[#a0a0a5]">Tags (comma-separated)</span>
             <input name="tags" defaultValue={post.tags?.join(', ')} className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2" />
           </label>
+
+          <fieldset className="space-y-2">
+            <legend className="text-sm text-[#a0a0a5]">Python libraries for this post</legend>
+            <div className="flex flex-wrap gap-4">
+              {AVAILABLE_PYTHON_PACKAGES.map((pkg) => (
+                <label key={pkg} className="inline-flex items-center gap-2 text-sm text-[#d7d7d7]">
+                  <input
+                    type="checkbox"
+                    name="pythonPackages"
+                    value={pkg}
+                    defaultChecked={post.pythonPackages?.includes(pkg)}
+                    className="accent-[#95bdc9]"
+                  />
+                  {pkg}
+                </label>
+              ))}
+            </div>
+          </fieldset>
 
           <label className="space-y-1 block">
             <span className="text-sm text-[#a0a0a5]">Content (Markdown)</span>

--- a/src/app/admin/blog/page.tsx
+++ b/src/app/admin/blog/page.tsx
@@ -89,7 +89,7 @@ export default async function AdminBlogPage() {
                 rows={12}
                 required
                 className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2 font-mono text-sm"
-                placeholder={'## Heading\n\nParagraph text\n\n```embed\nhttps://example.com/widget\n```'}
+                placeholder={'## Heading\n\nParagraph text\n\n```embed\nhttps://example.com/widget\n```\n\n```python-run\nprint(2 + 2)\n```'}
               />
             </label>
 

--- a/src/app/admin/blog/page.tsx
+++ b/src/app/admin/blog/page.tsx
@@ -4,6 +4,8 @@ import { clearAdminSession, requireAdminAuth } from '@/lib/admin-auth';
 import { createPostFile, type PostFormInput } from '@/lib/blog-admin';
 import { getSortedPostsData } from '@/lib/blog';
 
+const AVAILABLE_PYTHON_PACKAGES = ['numpy', 'matplotlib', 'pandas', 'scipy'];
+
 export default async function AdminBlogPage() {
   await requireAdminAuth();
 
@@ -19,6 +21,11 @@ export default async function AdminBlogPage() {
       date: String(formData.get('date') ?? ''),
       excerpt: String(formData.get('excerpt') ?? ''),
       tags: String(formData.get('tags') ?? ''),
+      pythonPackages: formData
+        .getAll('pythonPackages')
+        .map((pkg) => String(pkg).trim())
+        .filter(Boolean)
+        .join(', '),
       content: String(formData.get('content') ?? ''),
     };
 
@@ -82,6 +89,19 @@ export default async function AdminBlogPage() {
               <input name="tags" className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2" />
             </label>
 
+            <fieldset className="space-y-2 md:col-span-2">
+              <legend className="text-sm text-[#a0a0a5]">Python libraries for this post</legend>
+              <div className="flex flex-wrap gap-4">
+                {AVAILABLE_PYTHON_PACKAGES.map((pkg) => (
+                  <label key={pkg} className="inline-flex items-center gap-2 text-sm text-[#d7d7d7]">
+                    <input type="checkbox" name="pythonPackages" value={pkg} className="accent-[#95bdc9]" />
+                    {pkg}
+                  </label>
+                ))}
+              </div>
+              <p className="text-xs text-[#888888]">Readers can run `python-run` blocks with these libraries preloaded.</p>
+            </fieldset>
+
             <label className="space-y-1 md:col-span-2">
               <span className="text-sm text-[#a0a0a5]">Content (Markdown)</span>
               <textarea
@@ -89,7 +109,7 @@ export default async function AdminBlogPage() {
                 rows={12}
                 required
                 className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2 font-mono text-sm"
-                placeholder={'## Heading\n\nParagraph text\n\n```embed\nhttps://example.com/widget\n```\n\n```python-run\nprint(2 + 2)\n```'}
+                placeholder={'## Heading\n\nParagraph text\n\n```embed\nhttps://example.com/widget\n```\n\n```python-run\nimport numpy as np\nprint(np.arange(5))\n```'}
               />
             </label>
 

--- a/src/app/admin/blog/page.tsx
+++ b/src/app/admin/blog/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { clearAdminSession, requireAdminAuth } from '@/lib/admin-auth';
-import { createPostFile, type PostFormInput } from '@/lib/blog-admin';
+import { createPostFile, deletePostFile, type PostFormInput } from '@/lib/blog-admin';
 import { getSortedPostsData } from '@/lib/blog';
 
 const AVAILABLE_PYTHON_PACKAGES = ['numpy', 'matplotlib', 'pandas', 'scipy'];
@@ -21,20 +21,22 @@ export default async function AdminBlogPage() {
       date: String(formData.get('date') ?? ''),
       excerpt: String(formData.get('excerpt') ?? ''),
       tags: String(formData.get('tags') ?? ''),
-      pythonPackages: Array.from(new Set([
-        ...formData
-          .getAll('pythonPackages')
-          .map((pkg) => String(pkg).trim())
-          .filter(Boolean),
-        ...String(formData.get('pythonPackagesExtra') ?? '')
-          .split(',')
-          .map((pkg) => pkg.trim())
-          .filter(Boolean),
-      ])).join(', '),
+      pythonPackages: Array.from(
+        new Set([
+          ...formData
+            .getAll('pythonPackages')
+            .map((pkg) => String(pkg).trim())
+            .filter(Boolean),
+          ...String(formData.get('pythonPackagesExtra') ?? '')
+            .split(',')
+            .map((pkg) => pkg.trim())
+            .filter(Boolean),
+        ]),
+      ).join(', '),
       content: String(formData.get('content') ?? ''),
     };
 
-    if (!payload.title || !payload.date || !payload.content) {
+    if (!payload.title || !payload.content) {
       redirect('/admin/blog?error=missing');
     }
 
@@ -45,6 +47,25 @@ export default async function AdminBlogPage() {
     }
 
     redirect('/admin/blog?created=1');
+  }
+
+  async function deletePost(formData: FormData) {
+    'use server';
+
+    await requireAdminAuth();
+
+    const slug = String(formData.get('slug') ?? '').trim();
+    if (!slug) {
+      redirect('/admin/blog?error=missing-slug');
+    }
+
+    try {
+      deletePostFile(slug);
+    } catch {
+      redirect('/admin/blog?error=delete');
+    }
+
+    redirect('/admin/blog?deleted=1');
   }
 
   async function logout() {
@@ -80,8 +101,9 @@ export default async function AdminBlogPage() {
             </label>
 
             <label className="space-y-1">
-              <span className="text-sm text-[#a0a0a5]">Date</span>
-              <input name="date" type="date" required className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2" />
+              <span className="text-sm text-[#a0a0a5]">Date & time (optional)</span>
+              <input name="date" type="datetime-local" className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2" />
+              <p className="text-xs text-[#7f7f82]">Leave empty to auto-use the current date/time at save.</p>
             </label>
 
             <label className="space-y-1 md:col-span-2">
@@ -107,12 +129,11 @@ export default async function AdminBlogPage() {
               <p className="text-xs text-[#888888]">Readers can run `python-run` blocks with these libraries preloaded.</p>
             </fieldset>
 
-
             <label className="space-y-1 md:col-span-2">
               <span className="text-sm text-[#a0a0a5]">Additional Python libraries (optional, comma-separated)</span>
               <input
                 name="pythonPackagesExtra"
-                placeholder="sympy, seaborn"
+                placeholder="seaborn, sympy"
                 className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2"
               />
             </label>
@@ -159,6 +180,15 @@ export default async function AdminBlogPage() {
                   >
                     Edit
                   </Link>
+                  <form action={deletePost}>
+                    <input type="hidden" name="slug" value={post.slug} />
+                    <button
+                      type="submit"
+                      className="rounded-md border border-red-800/80 px-3 py-1 text-sm text-red-300 hover:border-red-500"
+                    >
+                      Delete
+                    </button>
+                  </form>
                 </div>
               </li>
             ))}

--- a/src/app/admin/blog/page.tsx
+++ b/src/app/admin/blog/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation';
 import { clearAdminSession, requireAdminAuth } from '@/lib/admin-auth';
 import { createPostFile, deletePostFile, type PostFormInput } from '@/lib/blog-admin';
 import { getSortedPostsData } from '@/lib/blog';
+import { DateTimeField } from '@/components/date-time-field';
 
 const AVAILABLE_PYTHON_PACKAGES = ['numpy', 'matplotlib', 'pandas', 'scipy'];
 
@@ -19,6 +20,7 @@ export default async function AdminBlogPage() {
     const payload: PostFormInput = {
       title: String(formData.get('title') ?? ''),
       date: String(formData.get('date') ?? ''),
+      timezone: String(formData.get('timezone') ?? ''),
       excerpt: String(formData.get('excerpt') ?? ''),
       tags: String(formData.get('tags') ?? ''),
       pythonPackages: Array.from(
@@ -101,9 +103,8 @@ export default async function AdminBlogPage() {
             </label>
 
             <label className="space-y-1">
-              <span className="text-sm text-[#a0a0a5]">Date & time (optional)</span>
-              <input name="date" type="datetime-local" className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2" />
-              <p className="text-xs text-[#7f7f82]">Leave empty to auto-use the current date/time at save.</p>
+              <span className="text-sm text-[#a0a0a5]">Date & time</span>
+              <DateTimeField />
             </label>
 
             <label className="space-y-1 md:col-span-2">

--- a/src/app/admin/blog/page.tsx
+++ b/src/app/admin/blog/page.tsx
@@ -1,0 +1,135 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { clearAdminSession, requireAdminAuth } from '@/lib/admin-auth';
+import { createPostFile, type PostFormInput } from '@/lib/blog-admin';
+import { getSortedPostsData } from '@/lib/blog';
+
+export default async function AdminBlogPage() {
+  await requireAdminAuth();
+
+  const posts = getSortedPostsData();
+
+  async function createPost(formData: FormData) {
+    'use server';
+
+    await requireAdminAuth();
+
+    const payload: PostFormInput = {
+      title: String(formData.get('title') ?? ''),
+      date: String(formData.get('date') ?? ''),
+      excerpt: String(formData.get('excerpt') ?? ''),
+      tags: String(formData.get('tags') ?? ''),
+      content: String(formData.get('content') ?? ''),
+    };
+
+    if (!payload.title || !payload.date || !payload.content) {
+      redirect('/admin/blog?error=missing');
+    }
+
+    try {
+      createPostFile(payload);
+    } catch {
+      redirect('/admin/blog?error=exists');
+    }
+
+    redirect('/admin/blog?created=1');
+  }
+
+  async function logout() {
+    'use server';
+
+    await clearAdminSession();
+    redirect('/admin/login');
+  }
+
+  return (
+    <main className="bg-[#000000] min-h-screen text-white px-4 py-8 md:px-10 lg:px-24">
+      <div className="max-w-5xl mx-auto space-y-8">
+        <header className="flex items-center justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold">Blog admin</h1>
+            <p className="text-[#a0a0a5] text-sm mt-1">Create and edit blog posts.</p>
+          </div>
+
+          <form action={logout}>
+            <button type="submit" className="rounded-md border border-[#2C2C2E] px-4 py-2 text-sm hover:border-[#95bdc9]">
+              Sign out
+            </button>
+          </form>
+        </header>
+
+        <section className="rounded-2xl border border-[#2C2C2E] bg-[#1C1C1E] p-6">
+          <h2 className="text-xl font-semibold mb-4">Create post</h2>
+
+          <form action={createPost} className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <label className="space-y-1">
+              <span className="text-sm text-[#a0a0a5]">Title</span>
+              <input name="title" required className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2" />
+            </label>
+
+            <label className="space-y-1">
+              <span className="text-sm text-[#a0a0a5]">Date</span>
+              <input name="date" type="date" required className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2" />
+            </label>
+
+            <label className="space-y-1 md:col-span-2">
+              <span className="text-sm text-[#a0a0a5]">Excerpt</span>
+              <input name="excerpt" className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2" />
+            </label>
+
+            <label className="space-y-1 md:col-span-2">
+              <span className="text-sm text-[#a0a0a5]">Tags (comma-separated)</span>
+              <input name="tags" className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2" />
+            </label>
+
+            <label className="space-y-1 md:col-span-2">
+              <span className="text-sm text-[#a0a0a5]">Content (Markdown)</span>
+              <textarea
+                name="content"
+                rows={12}
+                required
+                className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2 font-mono text-sm"
+                placeholder={'## Heading\n\nParagraph text\n\n```embed\nhttps://example.com/widget\n```'}
+              />
+            </label>
+
+            <div className="md:col-span-2">
+              <button type="submit" className="rounded-md bg-[#95bdc9] text-black font-semibold px-4 py-2 hover:opacity-90">
+                Save post
+              </button>
+            </div>
+          </form>
+        </section>
+
+        <section className="rounded-2xl border border-[#2C2C2E] bg-[#1C1C1E] p-6">
+          <h2 className="text-xl font-semibold mb-4">Existing posts</h2>
+
+          <ul className="space-y-3">
+            {posts.map((post) => (
+              <li key={post.slug} className="flex flex-wrap items-center justify-between gap-3 border border-[#2C2C2E] rounded-md p-3">
+                <div>
+                  <p className="font-medium">{post.title}</p>
+                  <p className="text-xs text-[#a0a0a5]">/{post.slug}</p>
+                </div>
+                <div className="flex gap-2">
+                  <Link
+                    href={`/blog/${post.slug}`}
+                    className="rounded-md border border-[#2C2C2E] px-3 py-1 text-sm hover:border-[#95bdc9]"
+                  >
+                    View
+                  </Link>
+                  <Link
+                    href={`/admin/blog/${post.slug}`}
+                    className="rounded-md border border-[#2C2C2E] px-3 py-1 text-sm hover:border-[#95bdc9]"
+                  >
+                    Edit
+                  </Link>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/admin/blog/page.tsx
+++ b/src/app/admin/blog/page.tsx
@@ -21,11 +21,16 @@ export default async function AdminBlogPage() {
       date: String(formData.get('date') ?? ''),
       excerpt: String(formData.get('excerpt') ?? ''),
       tags: String(formData.get('tags') ?? ''),
-      pythonPackages: formData
-        .getAll('pythonPackages')
-        .map((pkg) => String(pkg).trim())
-        .filter(Boolean)
-        .join(', '),
+      pythonPackages: Array.from(new Set([
+        ...formData
+          .getAll('pythonPackages')
+          .map((pkg) => String(pkg).trim())
+          .filter(Boolean),
+        ...String(formData.get('pythonPackagesExtra') ?? '')
+          .split(',')
+          .map((pkg) => pkg.trim())
+          .filter(Boolean),
+      ])).join(', '),
       content: String(formData.get('content') ?? ''),
     };
 
@@ -101,6 +106,16 @@ export default async function AdminBlogPage() {
               </div>
               <p className="text-xs text-[#888888]">Readers can run `python-run` blocks with these libraries preloaded.</p>
             </fieldset>
+
+
+            <label className="space-y-1 md:col-span-2">
+              <span className="text-sm text-[#a0a0a5]">Additional Python libraries (optional, comma-separated)</span>
+              <input
+                name="pythonPackagesExtra"
+                placeholder="sympy, seaborn"
+                className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2"
+              />
+            </label>
 
             <label className="space-y-1 md:col-span-2">
               <span className="text-sm text-[#a0a0a5]">Content (Markdown)</span>

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,0 +1,62 @@
+import { createAdminSession, isAdminAuthenticated } from '@/lib/admin-auth';
+import { redirect } from 'next/navigation';
+
+export default async function AdminLoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string }>;
+}) {
+  if (await isAdminAuthenticated()) {
+    redirect('/admin/blog');
+  }
+
+  const { error } = await searchParams;
+
+  async function login(formData: FormData) {
+    'use server';
+
+    const password = String(formData.get('password') ?? '');
+    const ok = await createAdminSession(password);
+
+    if (!ok) {
+      redirect('/admin/login?error=invalid');
+    }
+
+    redirect('/admin/blog');
+  }
+
+  return (
+    <main className="bg-[#000000] min-h-screen text-white flex items-center justify-center px-4">
+      <div className="w-full max-w-md rounded-2xl border border-[#2C2C2E] bg-[#1C1C1E] p-8">
+        <h1 className="text-2xl font-semibold mb-2">Admin login</h1>
+        <p className="text-[#a0a0a5] text-sm mb-6">Enter your admin password to manage blog posts.</p>
+
+        {error === 'invalid' ? (
+          <p className="text-red-300 text-sm mb-4">Invalid password. Please try again.</p>
+        ) : null}
+
+        <form action={login} className="space-y-4">
+          <div className="space-y-2">
+            <label htmlFor="password" className="text-sm text-[#a0a0a5]">
+              Password
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              required
+              className="w-full rounded-md bg-[#000000] border border-[#2C2C2E] px-3 py-2 outline-none focus:border-[#95bdc9]"
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="w-full rounded-md bg-[#95bdc9] text-black font-semibold px-4 py-2 hover:opacity-90 transition-opacity"
+          >
+            Sign in
+          </button>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { ChevronLeft, Calendar } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import type { Components } from 'react-markdown';
+import { PythonRunner } from '@/components/python-runner';
 
 const ALLOWED_EMBED_HOSTS = new Set(['codepen.io', 'codesandbox.io', 'stackblitz.com']);
 
@@ -37,6 +38,10 @@ const markdownComponents: Components = {
       } catch {
         return <p className="text-sm text-red-300">Invalid embed URL in embed code block.</p>;
       }
+    }
+
+    if (className === 'language-python-run') {
+      return <PythonRunner code={raw} />;
     }
 
     return (

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -85,7 +85,7 @@ export default async function BlogPost({ params }: { params: Promise<{ slug: str
 
           <div className="flex items-center gap-2 text-[#888888] text-sm mb-4 font-mono">
             <Calendar className="w-4 h-4" />
-            <time>{new Date(post.date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}</time>
+            <time>{new Date(post.date).toLocaleString('en-US', { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' })}</time>
           </div>
 
           <h1 className="text-4xl md:text-5xl font-bold tracking-tight text-[#e8e8e8] mb-6">

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -3,6 +3,49 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { ChevronLeft, Calendar } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
+import type { Components } from 'react-markdown';
+
+const ALLOWED_EMBED_HOSTS = new Set(['codepen.io', 'codesandbox.io', 'stackblitz.com']);
+
+const markdownComponents: Components = {
+  code({ className, children, ...props }) {
+    const raw = String(children).trim();
+
+    if (className === 'language-embed') {
+      try {
+        const embedUrl = new URL(raw);
+
+        if (!ALLOWED_EMBED_HOSTS.has(embedUrl.hostname)) {
+          return (
+            <p className="text-sm text-red-300 border border-red-800/60 bg-red-900/20 rounded-md p-3">
+              Blocked embed host: <strong>{embedUrl.hostname}</strong>
+            </p>
+          );
+        }
+
+        return (
+          <div className="my-6 rounded-xl overflow-hidden border border-[#2C2C2E]">
+            <iframe
+              title={`Embedded demo from ${embedUrl.hostname}`}
+              src={embedUrl.toString()}
+              loading="lazy"
+              className="w-full min-h-[380px] bg-[#0a0a0a]"
+              sandbox="allow-scripts allow-same-origin allow-popups allow-forms"
+            />
+          </div>
+        );
+      } catch {
+        return <p className="text-sm text-red-300">Invalid embed URL in embed code block.</p>;
+      }
+    }
+
+    return (
+      <code className={className} {...props}>
+        {children}
+      </code>
+    );
+  },
+};
 
 export async function generateStaticParams() {
   const posts = getSortedPostsData();
@@ -22,26 +65,26 @@ export default async function BlogPost({ params }: { params: Promise<{ slug: str
   return (
     <div className="bg-[#000000] min-h-screen text-white pt-24 pb-20 px-4 md:px-8 lg:px-16 relative">
       <div className="absolute top-0 left-0 w-full h-[50vh] bg-gradient-to-b from-[#0a0a0a] to-transparent z-0"></div>
-      
+
       <article className="max-w-3xl mx-auto relative z-10 animate-in fade-in duration-1000">
         <div className="mb-12">
-          <Link 
-            href="/blog" 
+          <Link
+            href="/blog"
             className="inline-flex items-center text-[#95bdc9] hover:text-white transition-colors duration-300 mb-8 font-medium"
           >
             <ChevronLeft className="w-4 h-4 mr-1" />
             Back to all posts
           </Link>
-          
+
           <div className="flex items-center gap-2 text-[#888888] text-sm mb-4 font-mono">
             <Calendar className="w-4 h-4" />
             <time>{new Date(post.date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}</time>
           </div>
-          
+
           <h1 className="text-4xl md:text-5xl font-bold tracking-tight text-[#e8e8e8] mb-6">
             {post.title}
           </h1>
-          
+
           <div className="flex flex-wrap gap-2 mb-8">
             {post.tags?.map((tag) => (
               <span key={tag} className="text-xs px-2 py-1 rounded bg-[#111111] border border-[#505050] text-[#95bdc9]">
@@ -50,9 +93,9 @@ export default async function BlogPost({ params }: { params: Promise<{ slug: str
             ))}
           </div>
         </div>
-        
+
         <div className="prose prose-invert prose-lg max-w-none prose-headings:text-[#e8e8e8] prose-a:text-[#95bdc9] hover:prose-a:text-white prose-a:transition-colors prose-p:text-[#888888] prose-strong:text-white prose-li:text-[#888888]">
-          <ReactMarkdown>{post.content}</ReactMarkdown>
+          <ReactMarkdown components={markdownComponents}>{post.content}</ReactMarkdown>
         </div>
       </article>
     </div>

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -8,49 +8,51 @@ import { PythonRunner } from '@/components/python-runner';
 
 const ALLOWED_EMBED_HOSTS = new Set(['codepen.io', 'codesandbox.io', 'stackblitz.com']);
 
-const markdownComponents: Components = {
-  code({ className, children, ...props }) {
-    const raw = String(children).trim();
+function getMarkdownComponents(pythonPackages: string[] = []): Components {
+  return {
+    code({ className, children, ...props }) {
+      const raw = String(children).trim();
 
-    if (className === 'language-embed') {
-      try {
-        const embedUrl = new URL(raw);
+      if (className === 'language-embed') {
+        try {
+          const embedUrl = new URL(raw);
 
-        if (!ALLOWED_EMBED_HOSTS.has(embedUrl.hostname)) {
+          if (!ALLOWED_EMBED_HOSTS.has(embedUrl.hostname)) {
+            return (
+              <p className="text-sm text-red-300 border border-red-800/60 bg-red-900/20 rounded-md p-3">
+                Blocked embed host: <strong>{embedUrl.hostname}</strong>
+              </p>
+            );
+          }
+
           return (
-            <p className="text-sm text-red-300 border border-red-800/60 bg-red-900/20 rounded-md p-3">
-              Blocked embed host: <strong>{embedUrl.hostname}</strong>
-            </p>
+            <div className="my-6 rounded-xl overflow-hidden border border-[#2C2C2E]">
+              <iframe
+                title={`Embedded demo from ${embedUrl.hostname}`}
+                src={embedUrl.toString()}
+                loading="lazy"
+                className="w-full min-h-[380px] bg-[#0a0a0a]"
+                sandbox="allow-scripts allow-same-origin allow-popups allow-forms"
+              />
+            </div>
           );
+        } catch {
+          return <p className="text-sm text-red-300">Invalid embed URL in embed code block.</p>;
         }
-
-        return (
-          <div className="my-6 rounded-xl overflow-hidden border border-[#2C2C2E]">
-            <iframe
-              title={`Embedded demo from ${embedUrl.hostname}`}
-              src={embedUrl.toString()}
-              loading="lazy"
-              className="w-full min-h-[380px] bg-[#0a0a0a]"
-              sandbox="allow-scripts allow-same-origin allow-popups allow-forms"
-            />
-          </div>
-        );
-      } catch {
-        return <p className="text-sm text-red-300">Invalid embed URL in embed code block.</p>;
       }
-    }
 
-    if (className === 'language-python-run') {
-      return <PythonRunner code={raw} />;
-    }
+      if (className === 'language-python-run') {
+        return <PythonRunner code={raw} packages={pythonPackages} />;
+      }
 
-    return (
-      <code className={className} {...props}>
-        {children}
-      </code>
-    );
-  },
-};
+      return (
+        <code className={className} {...props}>
+          {children}
+        </code>
+      );
+    },
+  };
+}
 
 export async function generateStaticParams() {
   const posts = getSortedPostsData();
@@ -100,7 +102,7 @@ export default async function BlogPost({ params }: { params: Promise<{ slug: str
         </div>
 
         <div className="prose prose-invert prose-lg max-w-none prose-headings:text-[#e8e8e8] prose-a:text-[#95bdc9] hover:prose-a:text-white prose-a:transition-colors prose-p:text-[#888888] prose-strong:text-white prose-li:text-[#888888]">
-          <ReactMarkdown components={markdownComponents}>{post.content}</ReactMarkdown>
+          <ReactMarkdown components={getMarkdownComponents(post.pythonPackages)}>{post.content}</ReactMarkdown>
         </div>
       </article>
     </div>

--- a/src/components/blog-section.tsx
+++ b/src/components/blog-section.tsx
@@ -26,7 +26,7 @@ export function BlogSection() {
             >
               <div className="flex items-center gap-2 text-[#95bdc9] text-sm mb-4 font-mono">
                 <Calendar className="w-4 h-4" />
-                <time>{new Date(post.date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}</time>
+                <time>{new Date(post.date).toLocaleString('en-US', { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' })}</time>
               </div>
 
               <h3 className="text-xl md:text-2xl font-bold text-[#e8e8e8] mb-3 tracking-tight group-hover:text-white transition-colors duration-300">

--- a/src/components/date-time-field.tsx
+++ b/src/components/date-time-field.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+function formatLocalDateTimeInput(date: Date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+function toIsoWithOffset(localDateTime: string) {
+  if (!localDateTime) {
+    return '';
+  }
+
+  const date = new Date(localDateTime);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  const offsetMinutes = -date.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? '+' : '-';
+  const absOffsetMinutes = Math.abs(offsetMinutes);
+  const offsetHours = String(Math.floor(absOffsetMinutes / 60)).padStart(2, '0');
+  const offsetMins = String(absOffsetMinutes % 60).padStart(2, '0');
+
+  return `${localDateTime}:00${sign}${offsetHours}:${offsetMins}`;
+}
+
+export function DateTimeField({ initialDate }: { initialDate?: string }) {
+  const fallbackLocal = useMemo(() => formatLocalDateTimeInput(new Date()), []);
+
+  const normalizedInitialDate = useMemo(() => {
+    if (!initialDate) {
+      return fallbackLocal;
+    }
+
+    const parsed = new Date(initialDate);
+    if (!Number.isNaN(parsed.getTime())) {
+      return formatLocalDateTimeInput(parsed);
+    }
+
+    if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(initialDate)) {
+      return initialDate;
+    }
+
+    return fallbackLocal;
+  }, [fallbackLocal, initialDate]);
+
+  const [localValue, setLocalValue] = useState(normalizedInitialDate);
+  const timezone = useMemo(
+    () => Intl.DateTimeFormat().resolvedOptions().timeZone || 'America/New_York',
+    [],
+  );
+
+  return (
+    <>
+      <input
+        name="dateLocal"
+        type="datetime-local"
+        value={localValue}
+        onChange={(event) => setLocalValue(event.target.value)}
+        className="w-full rounded-md bg-black border border-[#2C2C2E] px-3 py-2"
+      />
+      <input type="hidden" name="date" value={toIsoWithOffset(localValue)} />
+      <input type="hidden" name="timezone" value={timezone} />
+      <p className="text-xs text-[#7f7f82]">Default is your current local date/time ({timezone}).</p>
+    </>
+  );
+}

--- a/src/components/python-runner.tsx
+++ b/src/components/python-runner.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+type PyodideApi = {
+  runPythonAsync: (code: string) => Promise<unknown>;
+};
+
+declare global {
+  interface Window {
+    loadPyodide?: (opts: { indexURL: string }) => Promise<PyodideApi>;
+    __pyodidePromise__?: Promise<PyodideApi>;
+  }
+}
+
+const PYODIDE_VERSION = '0.27.7';
+
+function createPyodideScriptTag() {
+  return new Promise<void>((resolve, reject) => {
+    if (document.querySelector(`script[data-pyodide-version="${PYODIDE_VERSION}"]`)) {
+      resolve();
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/pyodide.js`;
+    script.async = true;
+    script.dataset.pyodideVersion = PYODIDE_VERSION;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error('Failed to load Pyodide runtime.'));
+    document.head.appendChild(script);
+  });
+}
+
+async function getPyodide() {
+  if (typeof window === 'undefined') {
+    throw new Error('Python runtime can only be loaded in the browser.');
+  }
+
+  if (!window.__pyodidePromise__) {
+    window.__pyodidePromise__ = (async () => {
+      await createPyodideScriptTag();
+
+      if (!window.loadPyodide) {
+        throw new Error('Pyodide loader is unavailable.');
+      }
+
+      return window.loadPyodide({
+        indexURL: `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/`,
+      });
+    })();
+  }
+
+  return window.__pyodidePromise__;
+}
+
+export function PythonRunner({ code }: { code: string }) {
+  const [output, setOutput] = useState('');
+  const [status, setStatus] = useState<'idle' | 'loading' | 'running' | 'done' | 'error'>('idle');
+  const [error, setError] = useState('');
+
+  const normalizedCode = useMemo(() => code.trim(), [code]);
+
+  async function runPython() {
+    setStatus('loading');
+    setOutput('');
+    setError('');
+
+    try {
+      const pyodide = await getPyodide();
+      setStatus('running');
+
+      const escapedCode = JSON.stringify(normalizedCode);
+      const result = await pyodide.runPythonAsync(`
+import io
+import sys
+import traceback
+
+_code = ${escapedCode}
+_stdout = io.StringIO()
+_stderr = io.StringIO()
+_old_stdout = sys.stdout
+_old_stderr = sys.stderr
+
+try:
+    sys.stdout = _stdout
+    sys.stderr = _stderr
+    exec(_code, {})
+except Exception:
+    traceback.print_exc()
+finally:
+    sys.stdout = _old_stdout
+    sys.stderr = _old_stderr
+
+_stdout.getvalue() + _stderr.getvalue()
+`);
+
+      setOutput(String(result ?? ''));
+      setStatus('done');
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Unknown Python execution error.');
+      setStatus('error');
+    }
+  }
+
+  return (
+    <div className="my-6 rounded-xl border border-[#2C2C2E] bg-[#111111] overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[#2C2C2E] bg-black/30">
+        <strong className="text-sm text-[#e8e8e8]">Python snippet</strong>
+        <button
+          type="button"
+          onClick={runPython}
+          disabled={status === 'loading' || status === 'running'}
+          className="rounded-md border border-[#3d5960] px-3 py-1 text-xs text-[#95bdc9] hover:text-white hover:border-[#95bdc9] disabled:opacity-50"
+        >
+          {status === 'loading' || status === 'running' ? 'Running…' : 'Run code'}
+        </button>
+      </div>
+
+      <pre className="m-0 p-4 overflow-x-auto text-sm text-[#d3d3d3] bg-[#0a0a0a]">
+        <code>{normalizedCode}</code>
+      </pre>
+
+      <div className="px-4 py-3 border-t border-[#2C2C2E]">
+        <p className="text-xs uppercase tracking-wider text-[#7f7f82] mb-2">Output</p>
+        {error ? (
+          <pre className="text-xs whitespace-pre-wrap text-red-300">{error}</pre>
+        ) : output ? (
+          <pre className="text-xs whitespace-pre-wrap text-[#a6d6a6]">{output}</pre>
+        ) : (
+          <p className="text-xs text-[#888888]">No output yet. Click “Run code” to execute this snippet.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/python-runner.tsx
+++ b/src/components/python-runner.tsx
@@ -7,6 +7,11 @@ type PyodideApi = {
   loadPackage: (packages: string | string[]) => Promise<void>;
 };
 
+type PythonExecutionResult = {
+  output: string;
+  plots: string[];
+};
+
 declare global {
   interface Window {
     loadPyodide?: (opts: { indexURL: string }) => Promise<PyodideApi>;
@@ -57,18 +62,20 @@ async function getPyodide() {
 
 export function PythonRunner({ code, packages = [] }: { code: string; packages?: string[] }) {
   const [output, setOutput] = useState('');
+  const [plots, setPlots] = useState<string[]>([]);
   const [status, setStatus] = useState<'idle' | 'loading' | 'running' | 'done' | 'error'>('idle');
   const [error, setError] = useState('');
 
   const normalizedCode = useMemo(() => code.trim(), [code]);
   const normalizedPackages = useMemo(
-    () => packages.map((pkg) => pkg.trim()).filter(Boolean),
+    () => Array.from(new Set(packages.map((pkg) => pkg.trim()).filter(Boolean))),
     [packages],
   );
 
   async function runPython() {
     setStatus('loading');
     setOutput('');
+    setPlots([]);
     setError('');
 
     try {
@@ -81,31 +88,58 @@ export function PythonRunner({ code, packages = [] }: { code: string; packages?:
       setStatus('running');
 
       const escapedCode = JSON.stringify(normalizedCode);
-      const result = await pyodide.runPythonAsync(`
+      const rawResult = await pyodide.runPythonAsync(`
 import io
 import sys
+import json
 import traceback
+import base64
+from io import BytesIO
 
 _code = ${escapedCode}
 _stdout = io.StringIO()
 _stderr = io.StringIO()
 _old_stdout = sys.stdout
 _old_stderr = sys.stderr
+_plot_images = []
 
 try:
+    try:
+        import matplotlib
+        matplotlib.use('Agg')
+    except Exception:
+        pass
+
     sys.stdout = _stdout
     sys.stderr = _stderr
     exec(_code, {})
+
+    try:
+        import matplotlib.pyplot as plt
+        for _fig_num in plt.get_fignums():
+            _fig = plt.figure(_fig_num)
+            _buf = BytesIO()
+            _fig.savefig(_buf, format='png', bbox_inches='tight')
+            _buf.seek(0)
+            _plot_images.append(base64.b64encode(_buf.read()).decode('ascii'))
+        plt.close('all')
+    except Exception:
+        pass
 except Exception:
-    traceback.print_exc()
+    traceback.print_exc(file=_stderr)
 finally:
     sys.stdout = _old_stdout
     sys.stderr = _old_stderr
 
-_stdout.getvalue() + _stderr.getvalue()
+json.dumps({
+    'output': _stdout.getvalue() + _stderr.getvalue(),
+    'plots': _plot_images,
+})
 `);
 
-      setOutput(String(result ?? ''));
+      const parsed = JSON.parse(String(rawResult ?? '{}')) as PythonExecutionResult;
+      setOutput(parsed.output ?? '');
+      setPlots(Array.isArray(parsed.plots) ? parsed.plots : []);
       setStatus('done');
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : 'Unknown Python execution error.');
@@ -136,15 +170,33 @@ _stdout.getvalue() + _stderr.getvalue()
         <code>{normalizedCode}</code>
       </pre>
 
-      <div className="px-4 py-3 border-t border-[#2C2C2E]">
-        <p className="text-xs uppercase tracking-wider text-[#7f7f82] mb-2">Output</p>
-        {error ? (
-          <pre className="text-xs whitespace-pre-wrap text-red-300">{error}</pre>
-        ) : output ? (
-          <pre className="text-xs whitespace-pre-wrap text-[#a6d6a6]">{output}</pre>
-        ) : (
-          <p className="text-xs text-[#888888]">No output yet. Click “Run code” to execute this snippet.</p>
-        )}
+      <div className="px-4 py-3 border-t border-[#2C2C2E] space-y-3">
+        <div>
+          <p className="text-xs uppercase tracking-wider text-[#7f7f82] mb-2">Output</p>
+          {error ? (
+            <pre className="text-xs whitespace-pre-wrap text-red-300">{error}</pre>
+          ) : output ? (
+            <pre className="text-xs whitespace-pre-wrap text-[#a6d6a6]">{output}</pre>
+          ) : (
+            <p className="text-xs text-[#888888]">No output yet. Click “Run code” to execute this snippet.</p>
+          )}
+        </div>
+
+        {plots.length > 0 ? (
+          <div>
+            <p className="text-xs uppercase tracking-wider text-[#7f7f82] mb-2">Plots</p>
+            <div className="space-y-3">
+              {plots.map((img, index) => (
+                <img
+                  key={`${index}-${img.slice(0, 16)}`}
+                  src={`data:image/png;base64,${img}`}
+                  alt={`Generated plot ${index + 1}`}
+                  className="w-full rounded-md border border-[#2C2C2E] bg-white"
+                />
+              ))}
+            </div>
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/src/components/python-runner.tsx
+++ b/src/components/python-runner.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 
 type PyodideApi = {
   runPythonAsync: (code: string) => Promise<unknown>;
+  loadPackage: (packages: string | string[]) => Promise<void>;
 };
 
 declare global {
@@ -54,12 +55,16 @@ async function getPyodide() {
   return window.__pyodidePromise__;
 }
 
-export function PythonRunner({ code }: { code: string }) {
+export function PythonRunner({ code, packages = [] }: { code: string; packages?: string[] }) {
   const [output, setOutput] = useState('');
   const [status, setStatus] = useState<'idle' | 'loading' | 'running' | 'done' | 'error'>('idle');
   const [error, setError] = useState('');
 
   const normalizedCode = useMemo(() => code.trim(), [code]);
+  const normalizedPackages = useMemo(
+    () => packages.map((pkg) => pkg.trim()).filter(Boolean),
+    [packages],
+  );
 
   async function runPython() {
     setStatus('loading');
@@ -68,6 +73,11 @@ export function PythonRunner({ code }: { code: string }) {
 
     try {
       const pyodide = await getPyodide();
+
+      if (normalizedPackages.length > 0) {
+        await pyodide.loadPackage(normalizedPackages);
+      }
+
       setStatus('running');
 
       const escapedCode = JSON.stringify(normalizedCode);
@@ -106,7 +116,12 @@ _stdout.getvalue() + _stderr.getvalue()
   return (
     <div className="my-6 rounded-xl border border-[#2C2C2E] bg-[#111111] overflow-hidden">
       <div className="flex items-center justify-between px-4 py-3 border-b border-[#2C2C2E] bg-black/30">
-        <strong className="text-sm text-[#e8e8e8]">Python snippet</strong>
+        <div>
+          <strong className="text-sm text-[#e8e8e8]">Python snippet</strong>
+          {normalizedPackages.length > 0 ? (
+            <p className="text-xs text-[#8baec0] mt-1">Preloaded: {normalizedPackages.join(', ')}</p>
+          ) : null}
+        </div>
         <button
           type="button"
           onClick={runPython}

--- a/src/components/python-runner.tsx
+++ b/src/components/python-runner.tsx
@@ -82,7 +82,24 @@ export function PythonRunner({ code, packages = [] }: { code: string; packages?:
       const pyodide = await getPyodide();
 
       if (normalizedPackages.length > 0) {
-        await pyodide.loadPackage(normalizedPackages);
+        const missingPackages: string[] = [];
+
+        for (const pkg of normalizedPackages) {
+          try {
+            await pyodide.loadPackage(pkg);
+          } catch {
+            missingPackages.push(pkg);
+          }
+        }
+
+        if (missingPackages.length > 0) {
+          await pyodide.loadPackage('micropip');
+          const escapedPackages = JSON.stringify(missingPackages);
+          await pyodide.runPythonAsync(`
+import micropip
+await micropip.install(${escapedPackages})
+`);
+        }
       }
 
       setStatus('running');

--- a/src/content/blog/hello-world.mdx
+++ b/src/content/blog/hello-world.mdx
@@ -13,6 +13,14 @@ We are a team of dedicated student engineers and AI researchers who believe in l
 
 ## Why We Started
 
-Drones have seen rapid adoption in industries like agriculture, videography, and logistics. However, we see the true potential of drones in life-saving scenarios. By leveraging AI advancements and powerful hardware, we aim to streamline emergency response and communication. 
+Drones have seen rapid adoption in industries like agriculture, videography, and logistics. However, we see the true potential of drones in life-saving scenarios. By leveraging AI advancements and powerful hardware, we aim to streamline emergency response and communication.
+
+## Interactive Demo Example
+
+We can now embed interactive demos right inside a blog post using an `embed` code fence:
+
+```embed
+https://stackblitz.com/edit/react-ts
+```
 
 Stay tuned for more updates on our progress, technical deep-dives into our AI algorithms, and news about our latest autonomous flight tests!

--- a/src/content/blog/hello-world.mdx
+++ b/src/content/blog/hello-world.mdx
@@ -3,6 +3,7 @@ title: "Welcome to ADDR"
 date: "2024-03-28"
 excerpt: "An introduction to Advanced Drone Development & Research and our vision for the future."
 tags: "company, vision, announcement"
+pythonPackages: "numpy, matplotlib"
 ---
 
 # Welcome to ADDR
@@ -28,9 +29,10 @@ https://stackblitz.com/edit/react-ts
 Use a `python-run` code fence to include code that readers can execute in the browser:
 
 ```python-run
-numbers = [5, 8, 13]
-print('sum:', sum(numbers))
-print('average:', sum(numbers) / len(numbers))
+import numpy as np
+numbers = np.array([5, 8, 13])
+print('sum:', numbers.sum())
+print('average:', numbers.mean())
 ```
 
 Stay tuned for more updates on our progress, technical deep-dives into our AI algorithms, and news about our latest autonomous flight tests!

--- a/src/content/blog/hello-world.mdx
+++ b/src/content/blog/hello-world.mdx
@@ -17,10 +17,20 @@ Drones have seen rapid adoption in industries like agriculture, videography, and
 
 ## Interactive Demo Example
 
-We can now embed interactive demos right inside a blog post using an `embed` code fence:
+We can embed interactive demos right inside a blog post using an `embed` code fence:
 
 ```embed
 https://stackblitz.com/edit/react-ts
+```
+
+## Runnable Python Example
+
+Use a `python-run` code fence to include code that readers can execute in the browser:
+
+```python-run
+numbers = [5, 8, 13]
+print('sum:', sum(numbers))
+print('average:', sum(numbers) / len(numbers))
 ```
 
 Stay tuned for more updates on our progress, technical deep-dives into our AI algorithms, and news about our latest autonomous flight tests!

--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -1,0 +1,57 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+const ADMIN_COOKIE_NAME = 'blog_admin_session';
+
+function getConfiguredPassword() {
+  const configured = process.env.BLOG_ADMIN_PASSWORD;
+
+  if (!configured) {
+    throw new Error('Missing BLOG_ADMIN_PASSWORD environment variable.');
+  }
+
+  return configured;
+}
+
+export async function isAdminAuthenticated() {
+  const cookieStore = await cookies();
+  const session = cookieStore.get(ADMIN_COOKIE_NAME)?.value;
+
+  if (!session) {
+    return false;
+  }
+
+  return session === getConfiguredPassword();
+}
+
+export async function requireAdminAuth() {
+  const authenticated = await isAdminAuthenticated();
+
+  if (!authenticated) {
+    redirect('/admin/login');
+  }
+}
+
+export async function createAdminSession(password: string) {
+  const configuredPassword = getConfiguredPassword();
+
+  if (password !== configuredPassword) {
+    return false;
+  }
+
+  const cookieStore = await cookies();
+  cookieStore.set(ADMIN_COOKIE_NAME, configuredPassword, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    maxAge: 60 * 60 * 8,
+  });
+
+  return true;
+}
+
+export async function clearAdminSession() {
+  const cookieStore = await cookies();
+  cookieStore.delete(ADMIN_COOKIE_NAME);
+}

--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -1,7 +1,9 @@
+import crypto from 'crypto';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
 const ADMIN_COOKIE_NAME = 'blog_admin_session';
+const SESSION_TTL_SECONDS = 60 * 60 * 8;
 
 function getConfiguredPassword() {
   const configured = process.env.BLOG_ADMIN_PASSWORD;
@@ -13,7 +15,63 @@ function getConfiguredPassword() {
   return configured;
 }
 
+function getSessionSecret() {
+  const secret = process.env.BLOG_ADMIN_SESSION_SECRET ?? process.env.BLOG_ADMIN_PASSWORD;
+
+  if (!secret) {
+    throw new Error('Missing BLOG_ADMIN_SESSION_SECRET or BLOG_ADMIN_PASSWORD environment variable.');
+  }
+
+  return secret;
+}
+
+function signPayload(payload: string) {
+  return crypto.createHmac('sha256', getSessionSecret()).update(payload).digest('base64url');
+}
+
+function createSessionToken() {
+  const expiresAt = Date.now() + SESSION_TTL_SECONDS * 1000;
+  const payload = `admin:${expiresAt}`;
+  const signature = signPayload(payload);
+  return `${payload}.${signature}`;
+}
+
+function validateSessionToken(token: string) {
+  const [payload, signature] = token.split('.');
+
+  if (!payload || !signature) {
+    return false;
+  }
+
+  const expected = signPayload(payload);
+  const signatureBuffer = Buffer.from(signature);
+  const expectedBuffer = Buffer.from(expected);
+
+  if (signatureBuffer.length !== expectedBuffer.length) {
+    return false;
+  }
+
+  if (!crypto.timingSafeEqual(signatureBuffer, expectedBuffer)) {
+    return false;
+  }
+
+  const [scope, expiresAtRaw] = payload.split(':');
+
+  if (scope !== 'admin') {
+    return false;
+  }
+
+  const expiresAt = Number(expiresAtRaw);
+  if (!Number.isFinite(expiresAt) || Date.now() > expiresAt) {
+    return false;
+  }
+
+  return true;
+}
+
 export async function isAdminAuthenticated() {
+  getConfiguredPassword();
+
   const cookieStore = await cookies();
   const session = cookieStore.get(ADMIN_COOKIE_NAME)?.value;
 
@@ -21,7 +79,7 @@ export async function isAdminAuthenticated() {
     return false;
   }
 
-  return session === getConfiguredPassword();
+  return validateSessionToken(session);
 }
 
 export async function requireAdminAuth() {
@@ -40,12 +98,12 @@ export async function createAdminSession(password: string) {
   }
 
   const cookieStore = await cookies();
-  cookieStore.set(ADMIN_COOKIE_NAME, configuredPassword, {
+  cookieStore.set(ADMIN_COOKIE_NAME, createSessionToken(), {
     httpOnly: true,
     sameSite: 'lax',
     secure: process.env.NODE_ENV === 'production',
     path: '/',
-    maxAge: 60 * 60 * 8,
+    maxAge: SESSION_TTL_SECONDS,
   });
 
   return true;

--- a/src/lib/blog-admin.ts
+++ b/src/lib/blog-admin.ts
@@ -1,0 +1,57 @@
+import fs from 'fs';
+import path from 'path';
+
+const postsDirectory = path.join(process.cwd(), 'src/content/blog');
+
+export interface PostFormInput {
+  title: string;
+  date: string;
+  excerpt: string;
+  tags: string;
+  content: string;
+}
+
+function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+}
+
+export function toMdxDocument(values: PostFormInput) {
+  return `---\ntitle: "${values.title.replace(/"/g, '\\\"')}"\ndate: "${values.date}"\nexcerpt: "${values.excerpt.replace(/"/g, '\\\"')}"\ntags: "${values.tags}"\n---\n\n${values.content.trim()}\n`;
+}
+
+export function createPostFile(values: PostFormInput) {
+  const slug = slugify(values.title);
+
+  if (!slug) {
+    throw new Error('Unable to generate a slug from title.');
+  }
+
+  if (!fs.existsSync(postsDirectory)) {
+    fs.mkdirSync(postsDirectory, { recursive: true });
+  }
+
+  const filePath = path.join(postsDirectory, `${slug}.mdx`);
+
+  if (fs.existsSync(filePath)) {
+    throw new Error('A post with this title already exists.');
+  }
+
+  fs.writeFileSync(filePath, toMdxDocument(values), 'utf8');
+
+  return slug;
+}
+
+export function updatePostFile(slug: string, values: PostFormInput) {
+  const filePath = path.join(postsDirectory, `${slug}.mdx`);
+
+  if (!fs.existsSync(filePath)) {
+    throw new Error('Post not found.');
+  }
+
+  fs.writeFileSync(filePath, toMdxDocument(values), 'utf8');
+}

--- a/src/lib/blog-admin.ts
+++ b/src/lib/blog-admin.ts
@@ -6,6 +6,7 @@ const postsDirectory = path.join(process.cwd(), 'src/content/blog');
 export interface PostFormInput {
   title: string;
   date: string;
+  timezone?: string;
   excerpt: string;
   tags: string;
   pythonPackages: string;
@@ -21,17 +22,41 @@ function slugify(value: string) {
     .replace(/-+/g, '-');
 }
 
-function resolveDate(dateInput: string) {
+function formatNowInTimeZone(timeZone: string) {
+  const now = new Date();
+  const formatter = new Intl.DateTimeFormat('sv-SE', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+
+  const parts = formatter.formatToParts(now);
+  const map = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+
+  return `${map.year}-${map.month}-${map.day}T${map.hour}:${map.minute}`;
+}
+
+function resolveDate(dateInput: string, timezone?: string) {
   const trimmed = dateInput.trim();
   if (trimmed) {
     return trimmed;
   }
 
-  return new Date().toISOString().slice(0, 16);
+  const tz = timezone?.trim() || 'America/New_York';
+
+  try {
+    return formatNowInTimeZone(tz);
+  } catch {
+    return formatNowInTimeZone('America/New_York');
+  }
 }
 
 export function toMdxDocument(values: PostFormInput) {
-  const date = resolveDate(values.date);
+  const date = resolveDate(values.date, values.timezone);
 
   return `---\ntitle: "${values.title.replace(/"/g, '\\\"')}"\ndate: "${date}"\nexcerpt: "${values.excerpt.replace(/"/g, '\\\"')}"\ntags: "${values.tags}"\npythonPackages: "${values.pythonPackages}"\n---\n\n${values.content.trim()}\n`;
 }

--- a/src/lib/blog-admin.ts
+++ b/src/lib/blog-admin.ts
@@ -8,6 +8,7 @@ export interface PostFormInput {
   date: string;
   excerpt: string;
   tags: string;
+  pythonPackages: string;
   content: string;
 }
 
@@ -21,7 +22,7 @@ function slugify(value: string) {
 }
 
 export function toMdxDocument(values: PostFormInput) {
-  return `---\ntitle: "${values.title.replace(/"/g, '\\\"')}"\ndate: "${values.date}"\nexcerpt: "${values.excerpt.replace(/"/g, '\\\"')}"\ntags: "${values.tags}"\n---\n\n${values.content.trim()}\n`;
+  return `---\ntitle: "${values.title.replace(/"/g, '\\\"')}"\ndate: "${values.date}"\nexcerpt: "${values.excerpt.replace(/"/g, '\\\"')}"\ntags: "${values.tags}"\npythonPackages: "${values.pythonPackages}"\n---\n\n${values.content.trim()}\n`;
 }
 
 export function createPostFile(values: PostFormInput) {

--- a/src/lib/blog-admin.ts
+++ b/src/lib/blog-admin.ts
@@ -21,8 +21,19 @@ function slugify(value: string) {
     .replace(/-+/g, '-');
 }
 
+function resolveDate(dateInput: string) {
+  const trimmed = dateInput.trim();
+  if (trimmed) {
+    return trimmed;
+  }
+
+  return new Date().toISOString().slice(0, 16);
+}
+
 export function toMdxDocument(values: PostFormInput) {
-  return `---\ntitle: "${values.title.replace(/"/g, '\\\"')}"\ndate: "${values.date}"\nexcerpt: "${values.excerpt.replace(/"/g, '\\\"')}"\ntags: "${values.tags}"\npythonPackages: "${values.pythonPackages}"\n---\n\n${values.content.trim()}\n`;
+  const date = resolveDate(values.date);
+
+  return `---\ntitle: "${values.title.replace(/"/g, '\\\"')}"\ndate: "${date}"\nexcerpt: "${values.excerpt.replace(/"/g, '\\\"')}"\ntags: "${values.tags}"\npythonPackages: "${values.pythonPackages}"\n---\n\n${values.content.trim()}\n`;
 }
 
 export function createPostFile(values: PostFormInput) {
@@ -55,4 +66,14 @@ export function updatePostFile(slug: string, values: PostFormInput) {
   }
 
   fs.writeFileSync(filePath, toMdxDocument(values), 'utf8');
+}
+
+export function deletePostFile(slug: string) {
+  const filePath = path.join(postsDirectory, `${slug}.mdx`);
+
+  if (!fs.existsSync(filePath)) {
+    throw new Error('Post not found.');
+  }
+
+  fs.unlinkSync(filePath);
 }

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -9,30 +9,47 @@ export interface BlogPost {
   excerpt: string;
   content: string;
   tags?: string[];
+  pythonPackages?: string[];
 }
 
 const postsDirectory = path.join(process.cwd(), 'src/content/blog');
 
+function parseStringArray(value: unknown): string[] {
+  if (!value) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item).trim()).filter(Boolean);
+  }
+
+  return String(value)
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
 export function getSortedPostsData(): BlogPost[] {
   if (!fs.existsSync(postsDirectory)) return [];
-  
+
   const fileNames = fs.readdirSync(postsDirectory);
   const allPostsData = fileNames
-    .filter(fileName => fileName.endsWith('.mdx') || fileName.endsWith('.md'))
+    .filter((fileName) => fileName.endsWith('.mdx') || fileName.endsWith('.md'))
     .map((fileName) => {
       const slug = fileName.replace(/\.mdx?$/, '');
       const fullPath = path.join(postsDirectory, fileName);
       const fileContents = fs.readFileSync(fullPath, 'utf8');
-      
+
       const { data, content } = matter(fileContents);
-      
+
       return {
         slug,
         title: data.title || 'Untitled',
         date: data.date || '2024-01-01',
         excerpt: data.excerpt || '',
-        tags: data.tags ? (typeof data.tags === 'string' ? data.tags.split(',').map((t: string) => t.trim()) : data.tags) : [],
-        content
+        tags: parseStringArray(data.tags),
+        pythonPackages: parseStringArray(data.pythonPackages),
+        content,
       };
     });
 
@@ -41,5 +58,5 @@ export function getSortedPostsData(): BlogPost[] {
 
 export function getPostData(slug: string): BlogPost | undefined {
   const posts = getSortedPostsData();
-  return posts.find(post => post.slug === slug);
+  return posts.find((post) => post.slug === slug);
 }


### PR DESCRIPTION
### Motivation

- Add an in-app, password-protected admin UI for creating and editing blog posts without needing to edit files directly.
- Persist posts as MDX files under `src/content/blog` and provide helper utilities to create and update them programmatically.
- Allow authors to embed interactive demos in post content using a fenced `embed` code block while restricting allowed hosts and sandboxing iframes.
- Document the admin flow and embed usage in `README.md` and include an example in the welcome post.

### Description

- Added admin pages for login, listing/creating posts, and editing posts at `src/app/admin/login`, `src/app/admin/blog`, and `src/app/admin/blog/[slug]` respectively, using server actions for create/update flows.
- Implemented `src/lib/admin-auth.ts` to manage a simple cookie-based session protected by the `BLOG_ADMIN_PASSWORD` environment variable and helper functions `isAdminAuthenticated`, `requireAdminAuth`, `createAdminSession`, and `clearAdminSession`.
- Implemented `src/lib/blog-admin.ts` with `createPostFile`, `updatePostFile`, `toMdxDocument`, and `PostFormInput` to generate slugged MDX filenames and write post files under `src/content/blog`.
- Extended the blog post renderer in `src/app/blog/[slug]/page.tsx` to parse `embed` fenced code blocks via `react-markdown`, whitelist `codepen.io`, `codesandbox.io`, and `stackblitz.com`, and render sandboxed `iframe`s for allowed embeds.
- Updated `README.md` with instructions for setting `BLOG_ADMIN_PASSWORD`, admin routes, and the `embed` code-fence format, and added an `embed` example to `src/content/blog/hello-world.mdx`.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d28b90c6c083308b19715ef237bba9)